### PR TITLE
Fix dropdown interactions

### DIFF
--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -9,14 +9,14 @@
                 <a class="nav-link" href="{{ path('home') }}">Home <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
                     Projects
                 </a>
                 {{ render(path('categories_menu')) }}
             </li>
             {% if is_granted('ROLE_ADMIN') %}
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
                         Manage
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">

--- a/templates/admin/admin_base.html.twig
+++ b/templates/admin/admin_base.html.twig
@@ -2,7 +2,7 @@
 
 {% block menu_items %}
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
         Manage
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -18,6 +18,9 @@
                     left: 100%;
                     margin-top: -1px;
                 }
+                .dropdown-submenu:hover > .dropdown-menu {
+                    display: block;
+                }
             </style>
         {% endblock %}
 

--- a/templates/category/_menu.html.twig
+++ b/templates/category/_menu.html.twig
@@ -3,7 +3,7 @@
     <div class="dropdown-divider"></div>
     {% for category in categories %}
         <div class="dropdown-submenu">
-            <a class="dropdown-item dropdown-toggle" href="{{ path('category_view', {id: category.id}) }}">{{ category.title }}</a>
+            <a class="dropdown-item dropdown-toggle" href="{{ path('category_view', {id: category.id}) }}" data-turbo="false">{{ category.title }}</a>
             <div class="dropdown-menu">
                 {% for project in category.projects %}
                     <a class="dropdown-item" href="{{ path('project_details', {id: project.id}) }}">{{ project.name }}</a>


### PR DESCRIPTION
## Summary
- keep Bootstrap dropdowns working when Turbo is enabled
- show category submenus on hover

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866e7955890832abec36e26dc3f0ba0