### PR TITLE
Implement dynamic project layout builder

### DIFF
--- a/migrations/Version20250704120000.php
+++ b/migrations/Version20250704120000.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250704120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds layout templates and project sections tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE layout_template (
+                id INT AUTO_INCREMENT NOT NULL,
+                name VARCHAR(100) NOT NULL,
+                slug VARCHAR(100) NOT NULL,
+                UNIQUE INDEX UNIQ_B4B7232C989D9B62 (slug),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE TABLE section (
+                id INT AUTO_INCREMENT NOT NULL,
+                project_id INT NOT NULL,
+                template_id INT NOT NULL,
+                position INT NOT NULL,
+                content LONGTEXT DEFAULT NULL,
+                INDEX IDX_2D737AE2166D1F9C (project_id),
+                INDEX IDX_2D737AE25DA0FB8A (template_id),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE TABLE section_image (
+                section_id INT NOT NULL,
+                image_id INT NOT NULL,
+                INDEX IDX_36DC492A6D80F353 (section_id),
+                INDEX IDX_36DC492A3DA5256D (image_id),
+                PRIMARY KEY(section_id, image_id)
+            ) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section
+                ADD CONSTRAINT FK_2D737AE2166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE,
+                ADD CONSTRAINT FK_2D737AE25DA0FB8A FOREIGN KEY (template_id) REFERENCES layout_template (id)
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section_image
+                ADD CONSTRAINT FK_36DC492A6D80F353 FOREIGN KEY (section_id) REFERENCES section (id) ON DELETE CASCADE,
+                ADD CONSTRAINT FK_36DC492A3DA5256D FOREIGN KEY (image_id) REFERENCES image (id) ON DELETE CASCADE
+        SQL);
+        $this->addSql(<<<'SQL'
+            INSERT INTO layout_template (name, slug) VALUES
+                ('Text', 'text'),
+                ('Image', 'image'),
+                ('Text and Image', 'text_image'),
+                ('Image and Text', 'image_text'),
+                ('Images grid', 'images_grid')
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section_image DROP FOREIGN KEY FK_36DC492A6D80F353
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section_image DROP FOREIGN KEY FK_36DC492A3DA5256D
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section DROP FOREIGN KEY FK_2D737AE2166D1F9C
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE section DROP FOREIGN KEY FK_2D737AE25DA0FB8A
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP TABLE section_image
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP TABLE section
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP TABLE layout_template
+        SQL);
+    }
+}

--- a/src/Entity/LayoutTemplate.php
+++ b/src/Entity/LayoutTemplate.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\LayoutTemplateRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LayoutTemplateRepository::class)]
+class LayoutTemplate
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $name = null;
+
+    #[ORM\Column(length: 100, unique: true)]
+    private ?string $slug = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): static
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+}

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\ProjectRepository;
+use App\Entity\Section;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -39,10 +40,17 @@ class Project
     #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'projects')]
     private Collection $categories;
 
+    /**
+     * @var Collection<int, Section>
+     */
+    #[ORM\OneToMany(targetEntity: Section::class, mappedBy: 'project', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $sections;
+
     public function __construct()
     {
         $this->images = new ArrayCollection();
         $this->categories = new ArrayCollection();
+        $this->sections = new ArrayCollection();
     }
 
 
@@ -145,6 +153,35 @@ class Project
     public function removeCategory(Category $categoryId): static
     {
         $this->categories->removeElement($categoryId);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Section>
+     */
+    public function getSections(): Collection
+    {
+        return $this->sections;
+    }
+
+    public function addSection(Section $section): static
+    {
+        if (!$this->sections->contains($section)) {
+            $this->sections->add($section);
+            $section->setProject($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSection(Section $section): static
+    {
+        if ($this->sections->removeElement($section)) {
+            if ($section->getProject() === $this) {
+                $section->setProject(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/Section.php
+++ b/src/Entity/Section.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\SectionRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: SectionRepository::class)]
+class Section
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'sections')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Project $project = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?LayoutTemplate $template = null;
+
+    #[ORM\Column]
+    private int $position = 0;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    /**
+     * @var Collection<int, Image>
+     */
+    #[ORM\ManyToMany(targetEntity: Image::class)]
+    #[ORM\JoinTable(name: 'section_image')]
+    private Collection $images;
+
+    public function __construct()
+    {
+        $this->images = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): static
+    {
+        $this->project = $project;
+
+        return $this;
+    }
+
+    public function getTemplate(): ?LayoutTemplate
+    {
+        return $this->template;
+    }
+
+    public function setTemplate(?LayoutTemplate $template): static
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): static
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Image>
+     */
+    public function getImages(): Collection
+    {
+        return $this->images;
+    }
+
+    public function addImage(Image $image): static
+    {
+        if (!$this->images->contains($image)) {
+            $this->images->add($image);
+        }
+
+        return $this;
+    }
+
+    public function removeImage(Image $image): static
+    {
+        $this->images->removeElement($image);
+
+        return $this;
+    }
+}

--- a/src/Form/AddProjectForm.php
+++ b/src/Form/AddProjectForm.php
@@ -4,6 +4,8 @@ namespace App\Form;
 
 use App\Entity\Category;
 use App\Entity\Project;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use App\Form\SectionType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -21,7 +23,15 @@ class AddProjectForm extends AbstractType
                 'choice_label' => 'title',
                 'multiple' => true,
             ])
-        ;
+            ->add('sections', CollectionType::class, [
+                'entry_type' => SectionType::class,
+                'entry_options' => [
+                    'project' => $builder->getData(),
+                ],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/SectionType.php
+++ b/src/Form/SectionType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Image;
+use App\Entity\LayoutTemplate;
+use App\Entity\Project;
+use App\Entity\Section;
+use App\Repository\ImageRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SectionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Project|null $project */
+        $project = $options['project'];
+
+        $builder
+            ->add('template', EntityType::class, [
+                'class' => LayoutTemplate::class,
+                'choice_label' => 'name',
+            ])
+            ->add('content', TextareaType::class, [
+                'required' => false,
+            ])
+            ->add('images', EntityType::class, [
+                'class' => Image::class,
+                'choice_label' => 'filename',
+                'multiple' => true,
+                'required' => false,
+                'query_builder' => function (ImageRepository $repo) use ($project) {
+                    return $repo->createQueryBuilder('i')
+                        ->andWhere('i.project = :project')
+                        ->setParameter('project', $project);
+                },
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Section::class,
+            'project' => null,
+        ]);
+        $resolver->setAllowedTypes('project', ['null', Project::class]);
+    }
+}

--- a/src/Repository/LayoutTemplateRepository.php
+++ b/src/Repository/LayoutTemplateRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LayoutTemplate;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class LayoutTemplateRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LayoutTemplate::class);
+    }
+}

--- a/src/Repository/SectionRepository.php
+++ b/src/Repository/SectionRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Section;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class SectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Section::class);
+    }
+}

--- a/templates/admin/add_project.html.twig
+++ b/templates/admin/add_project.html.twig
@@ -10,6 +10,7 @@
         {{ form_row(form.name) }}
         {{ form_row(form.description) }}
         {{ form_row(form.categories) }}
+        {{ form_row(form.sections) }}
         <button class="btn btn-primary">Save</button>
         {{ form_end(form) }}
     </div>

--- a/templates/projects/details.html.twig
+++ b/templates/projects/details.html.twig
@@ -12,6 +12,10 @@
         <p>Last updated: {{ project.updatedAt|date('Y-m-d H:i') }}</p>
     </div>
 
+    {% for section in project.sections %}
+        {% include 'projects/sections/' ~ section.template.slug ~ '.html.twig' with { 'section': section } %}
+    {% endfor %}
+
     {% if project.images|length > 0 %}
         <div class="row mt-4">
             {% for image in project.images %}

--- a/templates/projects/sections/image.html.twig
+++ b/templates/projects/sections/image.html.twig
@@ -1,0 +1,5 @@
+<section class="project-section">
+    {% if section.images|length %}
+        <img src="{{ asset('images/' ~ section.images.first.filename) }}" class="img-fluid w-100" alt="">
+    {% endif %}
+</section>

--- a/templates/projects/sections/image_text.html.twig
+++ b/templates/projects/sections/image_text.html.twig
@@ -1,0 +1,12 @@
+<section class="project-section">
+    <div class="row align-items-center">
+        <div class="col-md-6">
+            {% if section.images|length %}
+                <img src="{{ asset('images/' ~ section.images.first.filename) }}" class="img-fluid w-100" alt="">
+            {% endif %}
+        </div>
+        <div class="col-md-6">
+            <p>{{ section.content }}</p>
+        </div>
+    </div>
+</section>

--- a/templates/projects/sections/images_grid.html.twig
+++ b/templates/projects/sections/images_grid.html.twig
@@ -1,0 +1,9 @@
+<section class="project-section">
+    <div class="row">
+        {% for image in section.images %}
+            <div class="col-md-4 mb-3">
+                <img src="{{ asset('images/' ~ image.filename) }}" class="img-fluid w-100" alt="">
+            </div>
+        {% endfor %}
+    </div>
+</section>

--- a/templates/projects/sections/text.html.twig
+++ b/templates/projects/sections/text.html.twig
@@ -1,0 +1,5 @@
+<section class="project-section text-center my-5">
+    <div class="container">
+        <p>{{ section.content }}</p>
+    </div>
+</section>

--- a/templates/projects/sections/text_image.html.twig
+++ b/templates/projects/sections/text_image.html.twig
@@ -1,0 +1,12 @@
+<section class="project-section">
+    <div class="row align-items-center">
+        <div class="col-md-6">
+            <p>{{ section.content }}</p>
+        </div>
+        <div class="col-md-6">
+            {% if section.images|length %}
+                <img src="{{ asset('images/' ~ section.images.first.filename) }}" class="img-fluid w-100" alt="">
+            {% endif %}
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add `LayoutTemplate` and `Section` entities
- allow projects to contain a collection of `Section` objects
- create `SectionType` form and extend project form to edit sections
- seed default layout templates via doctrine migration
- render project sections dynamically in templates
- provide twig partials for each layout option

## Testing
- `./vendor/bin/phpunit -c phpunit.dist.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686786c0227c832a9d25434e2bab7f7e