### PR TITLE
Add dynamic sections Stimulus controller

### DIFF
--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -9,6 +9,10 @@
                 "enabled": false,
                 "fetch": "eager"
             }
+        },
+        "section-collection": {
+            "enabled": true,
+            "fetch": "lazy"
         }
     },
     "entrypoints": []

--- a/assets/controllers/section_collection_controller.js
+++ b/assets/controllers/section_collection_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['collection', 'prototype'];
+    static values = { index: Number };
+
+    connect() {
+        if (isNaN(this.indexValue)) {
+            this.indexValue = this.collectionTarget.children.length;
+        }
+    }
+
+    add(event) {
+        event.preventDefault();
+        const content = this.prototypeTarget.innerHTML.replace(/__name__/g, this.indexValue);
+        const element = document.createElement('div');
+        element.setAttribute('data-section-collection-target', 'item');
+        element.innerHTML = content;
+        this.collectionTarget.appendChild(element);
+        this.indexValue++;
+    }
+
+    remove(event) {
+        event.preventDefault();
+        const item = event.currentTarget.closest('[data-section-collection-target="item"]');
+        if (item) {
+            item.remove();
+        }
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -25,4 +25,7 @@ return [
     '@hotwired/turbo' => [
         'version' => '7.3.0',
     ],
+    'controllers/section_collection_controller' => [
+        'path' => './assets/controllers/section_collection_controller.js',
+    ],
 ];

--- a/templates/admin/add_project.html.twig
+++ b/templates/admin/add_project.html.twig
@@ -10,7 +10,23 @@
         {{ form_row(form.name) }}
         {{ form_row(form.description) }}
         {{ form_row(form.categories) }}
-        {{ form_row(form.sections) }}
+        <div data-controller="section-collection">
+            <div data-section-collection-target="collection">
+                {% for sectionField in form.sections %}
+                    <div data-section-collection-target="item" class="mb-3">
+                        {{ form_row(sectionField) }}
+                        <button type="button" class="btn btn-danger mt-2" data-action="section-collection#remove">Remove</button>
+                    </div>
+                {% endfor %}
+            </div>
+            <template data-section-collection-target="prototype">
+                <div data-section-collection-target="item" class="mb-3">
+                    {{ form_row(form.sections.vars.prototype) }}
+                    <button type="button" class="btn btn-danger mt-2" data-action="section-collection#remove">Remove</button>
+                </div>
+            </template>
+            <button type="button" class="btn btn-secondary" data-action="section-collection#add">Add section</button>
+        </div>
         <button class="btn btn-primary">Save</button>
         {{ form_end(form) }}
     </div>

--- a/templates/admin/manage_project.html.twig
+++ b/templates/admin/manage_project.html.twig
@@ -6,7 +6,26 @@
     <div class="container mt-4">
         <h1 class="mb-4">Edit Project</h1>
         {{ form_start(form) }}
-        {{ form_widget(form) }}
+        {{ form_row(form.name) }}
+        {{ form_row(form.description) }}
+        {{ form_row(form.categories) }}
+        <div data-controller="section-collection">
+            <div data-section-collection-target="collection">
+                {% for sectionField in form.sections %}
+                    <div data-section-collection-target="item" class="mb-3">
+                        {{ form_row(sectionField) }}
+                        <button type="button" class="btn btn-danger mt-2" data-action="section-collection#remove">Remove</button>
+                    </div>
+                {% endfor %}
+            </div>
+            <template data-section-collection-target="prototype">
+                <div data-section-collection-target="item" class="mb-3">
+                    {{ form_row(form.sections.vars.prototype) }}
+                    <button type="button" class="btn btn-danger mt-2" data-action="section-collection#remove">Remove</button>
+                </div>
+            </template>
+            <button type="button" class="btn btn-secondary" data-action="section-collection#add">Add section</button>
+        </div>
         <button class="btn btn-primary">Save</button>
         {{ form_end(form) }}
         <a href="{{ path('admin_manage_projects') }}" class="btn btn-secondary mt-3">Back to list</a>


### PR DESCRIPTION
## Summary
- add a Stimulus controller to dynamically manage SectionType collections
- register new controller in controllers.json and importmap.php
- update project admin templates to support add/remove section forms

## Testing
- `npm run build` *(fails: Could not find package.json)*
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6867d808f01c832aa907b36e63772a3f