### PR TITLE
Fix Bootstrap dropdown with importmap

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6,6 +6,7 @@ import './bootstrap.js';
  * which should already be in your base.html.twig.
  */
 
+import '@popperjs/core';
 import 'jquery';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <a class="navbar-brand" href="{{ path('home') }}">Snejyx</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
@@ -9,14 +9,14 @@
                 <a class="nav-link" href="{{ path('home') }}">Home <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="projectsDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
+                <a class="nav-link dropdown-toggle" href="#" id="projectsDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
                     Projects
                 </a>
                 {{ render(path('categories_menu')) }}
             </li>
             {% if is_granted('ROLE_ADMIN') %}
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="manageDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
+                    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="manageDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
                         Manage
                     </a>
                     <div class="dropdown-menu" aria-labelledby="manageDropdownMenuLink">

--- a/templates/admin/admin_base.html.twig
+++ b/templates/admin/admin_base.html.twig
@@ -2,7 +2,7 @@
 
 {% block menu_items %}
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
+    <a class="nav-link dropdown-toggle" href="{{ path('admin') }}" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-turbo="false">
         Manage
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">

--- a/templates/category/_menu.html.twig
+++ b/templates/category/_menu.html.twig
@@ -3,7 +3,7 @@
     <div class="dropdown-divider"></div>
     {% for category in categories %}
         <div class="dropdown-submenu">
-            <a class="dropdown-item dropdown-toggle" href="{{ path('category_view', {id: category.id}) }}" data-turbo="false">{{ category.title }}</a>
+            <a class="dropdown-item dropdown-toggle" href="{{ path('category_view', {id: category.id}) }}" data-turbo="false" data-bs-toggle="dropdown">{{ category.title }}</a>
             <div class="dropdown-menu">
                 {% for project in category.projects %}
                     <a class="dropdown-item" href="{{ path('project_details', {id: project.id}) }}">{{ project.name }}</a>


### PR DESCRIPTION
## Summary
- include Popper before Bootstrap scripts
- update Bootstrap markup to v5 `data-bs-*` attributes

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d2d729758832aaf9c6534dea8e5ca